### PR TITLE
Replace /var/spool/cwl with portable reference

### DIFF
--- a/repeatmasker.cwl
+++ b/repeatmasker.cwl
@@ -152,7 +152,11 @@ inputs:
     inputBinding:   # TODO: need to pick up this output
       prefix: "-gff"
 
-baseCommand: [ "RepeatMasker", "-dir", "/var/spool/cwl" ]
+baseCommand: [ RepeatMasker ]
+
+arguments:
+  - prefix: -dir
+    valueFrom: $(runtime.outdir)
 
 # stdout: masked.fasta
 


### PR DESCRIPTION
`/var/spool/cwl` is not part of the CWL v1.x standards. See https://github.com/common-workflow-language/common-workflow-language/issues/674 for a discussion.